### PR TITLE
support command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,19 @@
 Service Control for configuring systemd services
 
 * ntsysv alike command line for systemd
+
+
+```sh
+[root@an3 rpmbuild]$ sh sc -h
+getopt: invalid option -- 'h'
+
+ntsysv-systemd: ntsysv alike command line for systemd
+Usage: sc -[ade]
+Options:
+         -a print state enabled, disabled and static
+         -d print only disabled state
+         -e print only enabled state
+    If do not give any options, print enabled or disabled state
+
+[root@an3 rpmbuild]$
+```

--- a/sc
+++ b/sc
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
-# Copyright (C) 2015 Chunhua Liu
+# Copyright (C) 2016 Chunhua Liu
+#
+# 2016.03.19 - support command line option with getopt by JoungKyun.Kim <http://oops.org>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -15,6 +17,41 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
+errmsg() {
+	echo "$*" > /dev/stderr
+}
+
+help() {
+	errmsg
+	errmsg "ntsysv-systemd: ntsysv alike command line for systemd"
+	errmsg "Usage: $0 -[ade]"
+	errmsg "Options:"
+	errmsg "         -a print state enabled, disabled and static"
+	errmsg "         -d print only disabled state"
+	errmsg "         -e print only enabled state"
+	errmsg "    If don't give any options, print enabled or disabled state"
+	errmsg
+
+	exit 1
+}
+
+opts=$(getopt aed $*)
+[ $? != 0 ] && help;
+
+stateopt="--state=enabled,disabled"
+
+set -- ${opts}
+for i
+do
+	case "$i" in
+		-a) stateopt=""; shift ;;
+		-d) stateopt="--state=disabled"; shift ;;
+		-e) stateopt="--state=enabled"; shift ;;
+		--) shift; break;
+	esac
+done
+
 
 line=$(stty size)
 items=($line)
@@ -52,7 +89,7 @@ do
 		checklist="$checklist $unit $state OFF"
 	fi
 	
-done <<< "$(systemctl list-unit-files --type=service)"
+done <<< "$(systemctl list-unit-files --type=service ${stateopt})"
 
 width=$((width+30))
 if (( width > $COLUMNS )); then
@@ -61,7 +98,7 @@ fi
 
 height=$(($LINES-5))
 
-services=$(whiptail --backtitle "sc 1.0 - (C) 2015 Chunhua Liu" --title "SystemD Services" --checklist "What services should be automatically started?" $height $width $((height-7)) $checklist 3>&1 1>&2 2>&3)
+services=$(whiptail --backtitle "sc 1.1 - (C) 2016 Chunhua Liu" --title "SystemD Services" --checklist "What services should be automatically started?" $height $width $((height-7)) $checklist 3>&1 1>&2 2>&3)
 
 if [ $? -ne 0 ]; then
 	exit 1


### PR DESCRIPTION
Suppot command line option.

Original sc prints all state. So I patched print state enabled,disable on default.

``` sh
[root@an3 rpmbuild]$ bash sc -h
getopt: invalid option -- 'h'

ntsysv-systemd: ntsysv alike command line for systemd
Usage: sc -[ade]
Options:
         -a print state enabled, disabled and static
         -d print only disabled state
         -e print only enabled state
    If do not give any options, print enabled or disabled state

[root@an3 rpmbuild]$
```
